### PR TITLE
Allow train model when arg no-cuda is True

### DIFF
--- a/Allfiles/Labs/02-train-model/script/train.py
+++ b/Allfiles/Labs/02-train-model/script/train.py
@@ -159,7 +159,7 @@ def main():
 
     torch.manual_seed(args.seed)
 
-    device = torch.device("cuda")
+    device = torch.device("cuda" if use_cuda else "cpu")
 
     kwargs = {"batch_size": args.batch_size}
     if use_cuda:


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 02-train-model

Fixes # 
- Allow training model using CPU if no-cuda arg is True

Changes proposed in this pull request:
from
`device = torch.device("cuda")`
to
`device = torch.device("cuda" if use_cuda else "cpu")`