### PR TITLE
Backfill missing lab metadata (4 files)

### DIFF
--- a/Instructions/00-set-up.md
+++ b/Instructions/00-set-up.md
@@ -1,6 +1,14 @@
 ---
 lab:
-    title: 'Set up: Create an Azure Machine Learning workspace'
+  title: 'Set up: Create an Azure Machine Learning workspace'
+  description: In this exercise, you will create and explore an Azure Machine Learning
+    workspace.
+  duration: 46 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Machine Learning
 ---
 
 # Create and Explore an Azure Machine Learning Workspace

--- a/Instructions/01-preprocess-data-rapids.md
+++ b/Instructions/01-preprocess-data-rapids.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Load and preprocess data with RAPIDS'
-    module: 'Module: Preprocessing large datasets with Azure Machine Learning'
+  title: Load and preprocess data with RAPIDS
+  module: 'Module: Preprocessing large datasets with Azure Machine Learning'
+  description: To use GPUs to load and preprocess data, data scientists can work with
+    the RAPIDS framework. More specifically, with the cuDF library. In this exercise,
+    you'll use cuDF to preprocess data with a GPU cluster in Azure Machine Learning.
+  duration: 36 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Machine Learning
 ---
 
 # Load and preprocess data with RAPIDS

--- a/Instructions/02-train-model-pytorch.md
+++ b/Instructions/02-train-model-pytorch.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Train a PyTorch model with a GPU compute cluster'
-    module: 'Module: Train compute-intensive models with Azure Machine Learning'
+  title: Train a PyTorch model with a GPU compute cluster
+  module: 'Module: Train compute-intensive models with Azure Machine Learning'
+  description: To train a model with GPUs, data scientists can work with the PyTorch
+    library. In this exercise, you'll use PyTorch to train a Convolutional Neural
+    Network (CNN) model on the MNIST data with a GPU cluster in Azure Machine Learning.
+  duration: 28 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Machine Learning
 ---
 
 # Train a PyTorch model with a GPU compute cluster

--- a/Instructions/03-deploy-triton.md
+++ b/Instructions/03-deploy-triton.md
@@ -1,7 +1,18 @@
 ---
 lab:
-    title: 'Deploy Triton with an ONNX model to a managed online endpoint'
-    module: 'Module: Deploy deep learning workloads to production with Azure Machine Learning'
+  title: Deploy Triton with an ONNX model to a managed online endpoint
+  module: 'Module: Deploy deep learning workloads to production with Azure Machine
+    Learning'
+  description: To deploy a model to an endpoint in Azure Machine Learning, you can
+    use NVIDIA Triton Inference Server. In this exercise, you'll register an ONNX
+    model that is already trained to the workspace. Deploying to an endpoint will
+    be easy thanks to Triton's no-code-deployment option in Azure Machine Learning.
+  duration: 10 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Machine Learning
 ---
 
 # Deploy Triton with an ONNX model to a managed online endpoint


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 4

- `Instructions/00-set-up.md` (description,duration,level,islab,primarytopics)
- `Instructions/01-preprocess-data-rapids.md` (description,duration,level,islab,primarytopics)
- `Instructions/02-train-model-pytorch.md` (description,duration,level,islab,primarytopics)
- `Instructions/03-deploy-triton.md` (description,duration,level,islab,primarytopics)
